### PR TITLE
Push releasing branch and next tag atomically

### DIFF
--- a/cmd_release.go
+++ b/cmd_release.go
@@ -205,7 +205,6 @@ func (re *release) do() error {
 			nextVer,
 			strings.TrimSpace(buf2.String())))
 	c.git("tag", nextTag)
-	c.git("push")
-	c.git("push", remote, nextTag)
+	c.git("push", "--atomic", remote, branch, "tag", nextTag)
 	return c.err
 }


### PR DESCRIPTION
I suggest using `--atomic` option on pushing the releasing branch and next tag. This prevents the releasing tag left unpushed on some rare situation of networking issue. Also I suggest using tag shorthand, to avoid ambiguity of the ref.